### PR TITLE
Use url instead of templateID

### DIFF
--- a/dev/src/command/CreateUserProjectCmd.ts
+++ b/dev/src/command/CreateUserProjectCmd.ts
@@ -65,7 +65,7 @@ async function promptForTemplate(connection: Connection): Promise<IMCTemplateDat
         return {
             ...type,
             detail: type.language,
-            extension: type.extension,
+            extension: type.url,
         };
     });
 

--- a/dev/src/microclimate/connection/UserProjectCreator.ts
+++ b/dev/src/microclimate/connection/UserProjectCreator.ts
@@ -21,7 +21,7 @@ import SocketEvents from "./SocketEvents";
 export interface IMCTemplateData {
     label: string;
     description: string;
-    extension: string;
+    url: string;
     language: string;
 }
 
@@ -121,7 +121,7 @@ namespace UserProjectCreator {
 
         const payload = {
             projectName: projectName,
-            templateID: projectTypeSelected.extension,
+            url: projectTypeSelected.url,
             parentPath: projectLocation,
         };
 

--- a/dev/src/test/TestConfig.ts
+++ b/dev/src/test/TestConfig.ts
@@ -17,7 +17,7 @@ namespace TestConfig {
         projectType: ProjectType;
         // The name of this project type's extension in Microclimate.
         // Undefined for node
-        templateID: string;
+        url: string;
         // We want to tests projects that can't be restarted too,
         // so tell the test whether or not the restart should succeed here.
         canRestart: boolean;
@@ -26,46 +26,47 @@ namespace TestConfig {
         projectID?: string;
     }
 
+
     const testableProjectTypes: ITestableProjectType[] = [
         {
             projectType: new ProjectType(ProjectType.InternalTypes.NODE, ProjectType.Languages.NODE),
             canRestart: true,
-            templateID: "nodeExpressTemplate",
+            url: "https://github.com/microclimate-dev2ops/nodeExpressTemplate",
         },
         {
             projectType: new ProjectType(ProjectType.InternalTypes.SPRING, ProjectType.Languages.JAVA),
             canRestart: true,
-            templateID: "springJavaTemplate",
+            url: "https://github.com/microclimate-dev2ops/springJavaTemplate",
         },
         {
             projectType: new ProjectType(ProjectType.InternalTypes.MICROPROFILE, ProjectType.Languages.JAVA),
             canRestart: true,
-            templateID: "springJavaTemplate",
+            url: "https://github.com/microclimate-dev2ops/javaMicroProfileTemplate",
         },
         {
             projectType: new ProjectType(ProjectType.InternalTypes.SWIFT, ProjectType.Languages.SWIFT),
             canRestart: false,
-            templateID: "swiftTemplate",
+            url: "https://github.com/microclimate-dev2ops/swiftTemplate",
         },
         {
             projectType: new ProjectType(ProjectType.InternalTypes.DOCKER, ProjectType.Languages.PYTHON),
             canRestart: false,
-            templateID: "templateExample",
+            url: "https://github.com/microclimate-dev2ops/SVTPythonTemplate",
         },
         {
             projectType: new ProjectType(ProjectType.InternalTypes.DOCKER, ProjectType.Languages.GO),
             canRestart: false,
-            templateID: "templateGoExample",
+            url: "https://github.com/microclimate-dev2ops/microclimateGoTemplate",
         }
     ];
 
-    export function getTemplateID(projectType: ProjectType): string {
+    export function getUrl(projectType: ProjectType): string {
         const found = testableProjectTypes.find((tpt) => tpt.projectType === projectType);
         if (!found) {
             // The templates we use for tests are expected to always exist in Microclimate
             throw new Error("Did not find template corresponding to " + projectType);
         }
-        return found.templateID;
+        return found.url;
     }
 
     const TYPES_ENV_VAR = "project_types";

--- a/dev/src/test/TestUtil.ts
+++ b/dev/src/test/TestUtil.ts
@@ -37,7 +37,7 @@ namespace TestUtil {
         try {
             // turn our internal project type into a user project type which we can pass to the project creator
             const typeForCreation: IMCTemplateData = {
-                extension: TestConfig.getTemplateID(type),
+                url: TestConfig.getUrl(type),
                 language: type.language,
                 // label and description are displayed to user but not used by the test.
                 description: "",


### PR DESCRIPTION
projects api has changed to now accept a url rather than a templateID.  Changes here to have the vscode plugin use those new values